### PR TITLE
Minor API enhancement for the Room Owner check

### DIFF
--- a/Runtime/RagonRoom.cs
+++ b/Runtime/RagonRoom.cs
@@ -157,5 +157,7 @@ namespace Ragon.Client
 
       _connection.SendData(sendData);
     }
+    
+    public bool OwnerIsMe() => RoomOwner == MyId;
   }
 }


### PR DESCRIPTION
To not write `RagonNetwork.Room.RoomOwner == RagonNetwork.Room.MyId` every time.
Instead, it will be `RagonNetwork.Room.OwnerIsMe()`.