### PR TITLE
Minor API enhancement for the Room Owner check

### DIFF
--- a/Runtime/RagonRoom.cs
+++ b/Runtime/RagonRoom.cs
@@ -157,5 +157,7 @@ namespace Ragon.Client
 
       _connection.SendData(sendData);
     }
+    
+    public bool OwnerIsMe() => RoomOwner == MyId;
   }
 }


### PR DESCRIPTION
_Reopened because of branch rename._

I want to suggest some API enhancement for the "Room Owner" check. 
To not write `RagonNetwork.Room.RoomOwner == RagonNetwork.Room.MyId` every time, we're adding a new method and now this check will be look like ` RagonNetwork.Room.OwnerIsMe()`. It also can prevent some mistakes in the client code.