### PR TITLE
Scan button for the Ragon Prefab Registry instead of OnValidate metod.

### DIFF
--- a/Editor/RagonPrefabRegistryEditor.cs
+++ b/Editor/RagonPrefabRegistryEditor.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Oleg Dzhuraev <godlikeaurora@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Ragon.Client.Unity
+{
+  [CustomEditor(typeof(RagonPrefabRegistry))]
+  public class RagonPrefabRegistryEditor : UnityEditor.Editor
+  { 
+    public override void OnInspectorGUI()
+    {
+	  DrawDefaultInspector();
+
+	  if (GUILayout.Button("Rescan"))
+	  {
+	    var registry = target as RagonPrefabRegistry;
+
+	    if (registry)
+	    {
+		  registry.Rescan();
+	    }
+	  }
+    }
+  }
+}

--- a/Sources/RagonPrefabRegistry.cs
+++ b/Sources/RagonPrefabRegistry.cs
@@ -82,6 +82,8 @@ namespace Ragon.Client.Unity
           }
         }
       }
+
+      EditorUtility.SetDirty(this);
     }
 #endif
   }

--- a/Sources/RagonPrefabRegistry.cs
+++ b/Sources/RagonPrefabRegistry.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Modifications copyright (C) 2023 Oleg Dzhuraev <godlikeaurora@gmail.com>
+
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -27,13 +29,11 @@ namespace Ragon.Client.Unity
     [HideInInspector] public ushort EntityType;
     public GameObject Prefab;
   }
-
-  [ExecuteInEditMode]
+  
   [CreateAssetMenu(fileName = "RagonPrefabRegistry")]
   public class RagonPrefabRegistry : ScriptableObject
   {
     [SerializeField] private List<EntityPrefab> _prefabs = new List<EntityPrefab>();
-    [SerializeField] private bool _scan = false;
 
     public IReadOnlyDictionary<ushort, GameObject> Prefabs => _prefabsMap;
     private Dictionary<ushort, GameObject> _prefabsMap = new Dictionary<ushort, GameObject>();
@@ -46,7 +46,7 @@ namespace Ragon.Client.Unity
     }
     
 #if UNITY_EDITOR
-    private void OnValidate()
+    public void Rescan()
     {
       _prefabs.Clear();
       var guids = AssetDatabase.FindAssets("t:Prefab");


### PR DESCRIPTION
OnValidate can be frequently called by Unity in some cases. Also it is not recommented to use AssetDatabase in OnValidate (causes SendMessage warnings by Unity), so, Rescan button looks like a good solution.